### PR TITLE
Add shared SSO schema and query helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ Scrape SSO reports from ADEM's eFile portal for a date range, download the PDFs,
 
 The repository now includes a reusable client and CLI that query ADEM's ArcGIS REST layer for SSO reports and export them directly to CSV. This path is intended to replace the ad hoc year-based scripts over time and can be reused by future web UIs or dashboards.
 
-- **Client:** `sso_client.py` exposes `SSOClient.fetch_ssos` with filters for permit/utility, date range, and optional county. The client handles ArcGIS pagination and flattens geometry (`x`, `y`) onto each record.
+- **Schema and filters:** `sso_schema.py` defines the canonical `SSORecord` shape plus the reusable `SSOQuery` filter model (shared by the CLI and future UI/dashboard code). See `docs/schema_and_filters.md` for details.
+- **Client:** `sso_client.py` exposes `SSOClient.fetch_ssos` with filters for permit/utility, date range, volume bounds, and optional county. The client handles ArcGIS pagination and flattens geometry (`x`, `y`) onto each record.
 - **CSV export:** `sso_export.py` writes the fetched records to CSV (supports `.gz` output).
 - **CLI:** `sso_download.py` uses the client and exporter to pull data from the ArcGIS API.
 
@@ -24,6 +25,9 @@ python sso_download.py --utility-id AL0046744 --start-date 2024-01-01 --end-date
 
 # Download with only a date range (requires --allow-no-filters)
 python sso_download.py --start-date 2024-01-01 --end-date 2024-12-31 --output data/ssos_all_2024.csv --allow-no-filters
+
+# Filter by volume range in gallons
+python sso_download.py --start-date 2024-01-01 --end-date 2024-12-31 --min-volume 10000 --output data/large_ssos_2024.csv
 ```
 
 The legacy Playwright-based downloader/parser scripts remain available below but are treated as legacy compared to the ArcGIS path above.

--- a/docs/schema_and_filters.md
+++ b/docs/schema_and_filters.md
@@ -1,0 +1,25 @@
+# SSO schema and filter helpers
+
+Module `sso_schema.py` centralizes how the ArcGIS REST SSO records are represented and how queries are built. It is intended to be shared by the CLI, future web UI, and dashboards so filters and field names stay aligned.
+
+## Canonical record shape
+
+`SSORecord` is a dataclass that exposes the key SSO fields with friendly snake_case names and parsed types:
+
+- Identity and utility: `sso_id`, `utility_id` (permit number), `utility_name`, `sewer_system`, `county`, `location_desc`
+- Timing: `date_sso_began`, `date_sso_stopped` as `datetime`
+- Magnitude and impact: `volume_gallons`, `cause`, `receiving_water`
+- Coordinates: `x`, `y`
+- `raw`: the full original record dictionary for any extra fields
+
+Use `normalize_sso_record` to convert a single raw ArcGIS feature (attributes + geometry) to an `SSORecord`, or `normalize_sso_records` to process a collection. The helpers are defensive and return `None` for fields that cannot be parsed instead of raising.
+
+## Shared query model
+
+`SSOQuery` captures the supported filters: utility (ID or name), county, date range, and optional volume range. Methods:
+
+- `validate()`: raises `ValueError` on obvious issues (start date after end date, negative or inverted volume bounds).
+- `build_where_clause()`: returns an ArcGIS SQL where clause with the filters applied. Date ranges are inclusive of the end date via `< end_date + 1 day`.
+- `to_query_params()`: returns a parameter dictionary (including `where` and `orderByFields`) suitable for `SSOClient.fetch_ssos`.
+
+Future consumers should prefer constructing an `SSOQuery` and passing it to the client instead of assembling where clauses manually.

--- a/sso_schema.py
+++ b/sso_schema.py
@@ -1,0 +1,195 @@
+"""Canonical schema and query helpers for SSO records."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta
+from typing import Any, Dict, Iterable, List, Mapping, Optional
+
+# Field names as returned by the ArcGIS layer
+UTILITY_ID_FIELD = "permit_no"
+UTILITY_NAME_FIELD = "permittee"
+COUNTY_FIELD = "county"
+START_DATE_FIELD = "date_sso_began"
+END_DATE_FIELD = "date_sso_stopped"
+VOLUME_GALLONS_FIELD = "volume_gallons"
+SSO_ID_FIELD = "sso_id"
+RECEIVING_WATER_FIELD = "receiving_water"
+CAUSE_FIELD = "cause"
+SEWER_SYSTEM_FIELD = "sewer_system"
+LOCATION_FIELD = "location"
+
+
+@dataclass
+class SSORecord:
+    """Canonical representation of an SSO record."""
+
+    sso_id: Optional[str]
+    utility_id: Optional[str]
+    utility_name: Optional[str]
+    sewer_system: Optional[str]
+    county: Optional[str]
+    location_desc: Optional[str]
+
+    date_sso_began: Optional[datetime]
+    date_sso_stopped: Optional[datetime]
+
+    volume_gallons: Optional[float]
+    cause: Optional[str]
+    receiving_water: Optional[str]
+
+    x: Optional[float]
+    y: Optional[float]
+
+    raw: Dict[str, Any]
+
+
+def _coerce_str(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    try:
+        return str(value)
+    except Exception:
+        return None
+
+
+def _coerce_float(value: Any) -> Optional[float]:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _parse_datetime(value: Any) -> Optional[datetime]:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value
+    # ArcGIS often returns epoch milliseconds for dates
+    if isinstance(value, (int, float)):
+        try:
+            # Treat values above year 3000 as milliseconds
+            if value > 10_000_000_000:
+                value = value / 1000.0
+            return datetime.fromtimestamp(value)
+        except (OSError, OverflowError, ValueError):
+            return None
+    if isinstance(value, str):
+        if value.isdigit():
+            return _parse_datetime(float(value))
+        for fmt in ("%Y-%m-%d", "%Y-%m-%d %H:%M:%S"):
+            try:
+                return datetime.strptime(value, fmt)
+            except ValueError:
+                continue
+        try:
+            return datetime.fromisoformat(value)
+        except ValueError:
+            return None
+    return None
+
+
+def normalize_sso_record(raw: Mapping[str, Any]) -> SSORecord:
+    """Convert a raw ArcGIS record to an :class:`SSORecord`.
+
+    The function is defensive: missing keys or parsing errors return ``None``
+    for the structured fields without raising exceptions. The original record
+    is preserved on ``raw`` for downstream consumers that need additional
+    attributes.
+    """
+
+    raw_dict = dict(raw)
+    return SSORecord(
+        sso_id=_coerce_str(raw_dict.get(SSO_ID_FIELD)),
+        utility_id=_coerce_str(raw_dict.get(UTILITY_ID_FIELD)),
+        utility_name=_coerce_str(raw_dict.get(UTILITY_NAME_FIELD) or raw_dict.get("utility_name")),
+        sewer_system=_coerce_str(raw_dict.get(SEWER_SYSTEM_FIELD)),
+        county=_coerce_str(raw_dict.get(COUNTY_FIELD)),
+        location_desc=_coerce_str(raw_dict.get("location_desc") or raw_dict.get(LOCATION_FIELD)),
+        date_sso_began=_parse_datetime(raw_dict.get(START_DATE_FIELD)),
+        date_sso_stopped=_parse_datetime(raw_dict.get(END_DATE_FIELD)),
+        volume_gallons=_coerce_float(raw_dict.get(VOLUME_GALLONS_FIELD)),
+        cause=_coerce_str(raw_dict.get(CAUSE_FIELD)),
+        receiving_water=_coerce_str(
+            raw_dict.get(RECEIVING_WATER_FIELD) or raw_dict.get("waterbody")
+        ),
+        x=_coerce_float(raw_dict.get("x")),
+        y=_coerce_float(raw_dict.get("y")),
+        raw=raw_dict,
+    )
+
+
+def normalize_sso_records(raw_records: Iterable[Mapping[str, Any]]) -> List[SSORecord]:
+    """Normalize a collection of raw records into :class:`SSORecord` objects."""
+
+    return [normalize_sso_record(record) for record in raw_records]
+
+
+@dataclass
+class SSOQuery:
+    """Filter model for querying the SSO ArcGIS layer."""
+
+    utility_id: Optional[str] = None
+    utility_name: Optional[str] = None
+    county: Optional[str] = None
+    start_date: Optional[date] = None
+    end_date: Optional[date] = None
+    min_volume_gallons: Optional[float] = None
+    max_volume_gallons: Optional[float] = None
+    extra_params: Optional[Dict[str, Any]] = None
+
+    def validate(self) -> None:
+        if self.start_date and self.end_date and self.start_date > self.end_date:
+            raise ValueError("start_date cannot be after end_date")
+        if self.min_volume_gallons is not None and self.min_volume_gallons < 0:
+            raise ValueError("min_volume_gallons cannot be negative")
+        if self.max_volume_gallons is not None and self.max_volume_gallons < 0:
+            raise ValueError("max_volume_gallons cannot be negative")
+        if (
+            self.min_volume_gallons is not None
+            and self.max_volume_gallons is not None
+            and self.min_volume_gallons > self.max_volume_gallons
+        ):
+            raise ValueError("min_volume_gallons cannot exceed max_volume_gallons")
+
+    def _quote(self, value: str) -> str:
+        return value.replace("'", "''")
+
+    def build_where_clause(self) -> str:
+        self.validate()
+        clauses: List[str] = ["1=1"]
+
+        if self.start_date and self.end_date:
+            end_limit = self.end_date + timedelta(days=1)
+            clauses.append(
+                f"{START_DATE_FIELD} >= DATE '{self.start_date} 00:00:00' "
+                f"AND {START_DATE_FIELD} < DATE '{end_limit} 00:00:00'"
+            )
+        elif self.start_date:
+            clauses.append(f"{START_DATE_FIELD} >= DATE '{self.start_date} 00:00:00'")
+        elif self.end_date:
+            end_limit = self.end_date + timedelta(days=1)
+            clauses.append(f"{START_DATE_FIELD} < DATE '{end_limit} 00:00:00'")
+
+        if self.county:
+            clauses.append(f"{COUNTY_FIELD} = '{self._quote(self.county)}'")
+        if self.utility_id:
+            clauses.append(f"{UTILITY_ID_FIELD} = '{self._quote(self.utility_id)}'")
+        if self.utility_name:
+            clauses.append(f"{UTILITY_NAME_FIELD} = '{self._quote(self.utility_name)}'")
+        if self.min_volume_gallons is not None:
+            clauses.append(f"{VOLUME_GALLONS_FIELD} >= {self.min_volume_gallons}")
+        if self.max_volume_gallons is not None:
+            clauses.append(f"{VOLUME_GALLONS_FIELD} <= {self.max_volume_gallons}")
+
+        return " AND ".join(clauses)
+
+    def to_query_params(self) -> Dict[str, Any]:
+        params: Dict[str, Any] = {
+            "where": self.build_where_clause(),
+            "orderByFields": START_DATE_FIELD,
+        }
+        if self.extra_params:
+            params.update(self.extra_params)
+        return params

--- a/tests/test_sso_schema.py
+++ b/tests/test_sso_schema.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from datetime import date, datetime
+
+import pytest
+
+from sso_schema import (
+    SSOQuery,
+    SSORecord,
+    normalize_sso_record,
+    normalize_sso_records,
+)
+
+
+def test_normalize_sso_record_parses_fields():
+    raw = {
+        "sso_id": "123",
+        "permit_no": "AL1234567",
+        "permittee": "Utility Name",
+        "sewer_system": "Combined",
+        "county": "Mobile",
+        "location": "Main St",
+        "date_sso_began": 1_700_000_000_000,  # epoch ms
+        "date_sso_stopped": "2023-11-02 05:00:00",
+        "volume_gallons": "42.5",
+        "cause": "Blockage",
+        "receiving_water": "River",
+        "x": "-86.123",
+        "y": 32.456,
+        "unexpected": "keep me",
+    }
+
+    record = normalize_sso_record(raw)
+
+    assert isinstance(record, SSORecord)
+    assert record.sso_id == "123"
+    assert record.utility_id == "AL1234567"
+    assert record.utility_name == "Utility Name"
+    assert record.sewer_system == "Combined"
+    assert record.county == "Mobile"
+    assert record.location_desc == "Main St"
+    assert isinstance(record.date_sso_began, datetime)
+    assert record.date_sso_began.year == 2023
+    assert isinstance(record.date_sso_stopped, datetime)
+    assert record.volume_gallons == 42.5
+    assert record.cause == "Blockage"
+    assert record.receiving_water == "River"
+    assert record.x == -86.123
+    assert record.y == 32.456
+    assert record.raw["unexpected"] == "keep me"
+
+
+def test_normalize_sso_records_preserves_order():
+    raws = [{"sso_id": "1"}, {"sso_id": "2"}]
+
+    records = normalize_sso_records(raws)
+
+    assert [record.sso_id for record in records] == ["1", "2"]
+
+
+def test_sso_query_builds_where_clause():
+    query = SSOQuery(
+        county="Mobile",
+        start_date=date(2024, 1, 1),
+        end_date=date(2024, 1, 31),
+        min_volume_gallons=10,
+        max_volume_gallons=100,
+    )
+
+    where = query.build_where_clause()
+
+    assert "date_sso_began >= DATE '2024-01-01 00:00:00'" in where
+    assert "date_sso_began < DATE '2024-02-01 00:00:00'" in where
+    assert "volume_gallons >= 10" in where
+    assert "volume_gallons <= 100" in where
+    assert "county = 'Mobile'" in where
+
+
+def test_sso_query_to_query_params_adds_extra_params():
+    query = SSOQuery(county="Mobile", extra_params={"resultRecordCount": 50})
+
+    params = query.to_query_params()
+
+    assert "where" in params
+    assert params["orderByFields"] == "date_sso_began"
+    assert params["resultRecordCount"] == 50
+
+
+@pytest.mark.parametrize(
+    "query_args",
+    [
+        {"start_date": date(2024, 2, 1), "end_date": date(2024, 1, 1)},
+        {"min_volume_gallons": -1},
+        {"max_volume_gallons": -1},
+        {"min_volume_gallons": 10, "max_volume_gallons": 5},
+    ],
+)
+def test_sso_query_validate_raises(query_args):
+    query = SSOQuery(**query_args)
+
+    with pytest.raises(ValueError):
+        query.validate()


### PR DESCRIPTION
## Summary
- add a canonical SSO schema module with normalization helpers and a shared query/filter model
- integrate SSOQuery into the client and CLI, adding volume filters and validation
- document the schema/filter layer and cover it with new tests

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f71ba7320832b902a2970a62d3148)