### PR TITLE
Add FastAPI web UI and API for SSO downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,20 @@ issues = run_basic_qa(records)
 
 Use these helpers in dashboards to drive charts and tables (for example totals by utility or month, top spills, and QA issue counts) rather than duplicating query logic.
 
+### Web UI & HTTP API (Module F)
+
+A lightweight FastAPI layer is available for quick filtered downloads and previews built on the same client and schema used by the CLI.
+
+- **Run locally:** `uvicorn webapp.api:app --reload`
+- **Endpoints:**
+  - `/` – minimal HTML UI with dropdowns for utility/county and date range inputs
+  - `/download` – CSV download for the selected filters
+  - `/summary` – brief JSON volume summary (uses `sso_analytics` helpers)
+  - `/filters` – metadata for populating UI dropdowns
+- **Config:** honors the same `SSO_API_BASE_URL`, `SSO_API_KEY`, and `SSO_API_TIMEOUT` env vars used by the CLI.
+
+This module is intended as a thin shell that future dashboards (Module G) can extend without re-implementing query or CSV logic.
+
 The legacy Playwright-based downloader/parser scripts remain available below but are treated as legacy compared to the ArcGIS path above.
 
 ## Repository layout and entry points

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+requests
+fastapi
+uvicorn
+Jinja2
+httpx
+pytest

--- a/sso_export.py
+++ b/sso_export.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import csv
 import gzip
 from pathlib import Path
-from typing import Iterable, List, Sequence
+from typing import IO, Iterable, List, Sequence
 
 
 def _determine_fieldnames(records: Sequence[dict]) -> List[str]:
@@ -14,18 +14,34 @@ def _determine_fieldnames(records: Sequence[dict]) -> List[str]:
     return sorted(keys)
 
 
+def _write_records_to_handle(records: List[dict], handle: IO[str]) -> None:
+    fieldnames = _determine_fieldnames(records)
+    if not fieldnames:
+        handle.write("")
+        return
+
+    writer = csv.DictWriter(handle, fieldnames=fieldnames)
+    writer.writeheader()
+    for row in records:
+        writer.writerow(row)
+
+
+def write_ssos_to_csv_filelike(records: Iterable[dict], handle: IO[str]) -> None:
+    """Write SSO records to a CSV file-like object.
+
+    This helper mirrors :func:`write_ssos_to_csv` but targets an existing
+    text handle, enabling in-memory CSV generation for HTTP responses or
+    other non-filesystem outputs.
+    """
+
+    records_list = list(records)
+    _write_records_to_handle(records_list, handle)
+
+
 def write_ssos_to_csv(records: Iterable[dict], output_path: str) -> None:
     records_list = list(records)
-    fieldnames = _determine_fieldnames(records_list)
 
     path = Path(output_path)
     open_fn = gzip.open if path.suffix == ".gz" else open
     with open_fn(path, "wt", encoding="utf-8", newline="") as csvfile:
-        if not fieldnames:
-            csvfile.write("")
-            return
-
-        writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
-        writer.writeheader()
-        for row in records_list:
-            writer.writerow(row)
+        _write_records_to_handle(records_list, csvfile)

--- a/tests/test_sso_export.py
+++ b/tests/test_sso_export.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 import csv
 import gzip
+from io import StringIO
 from pathlib import Path
 
-from sso_export import write_ssos_to_csv
+from sso_export import write_ssos_to_csv, write_ssos_to_csv_filelike
 
 
 def test_write_ssos_to_csv_creates_expected_headers(tmp_path: Path):
@@ -44,3 +45,16 @@ def test_write_ssos_to_csv_handles_empty(tmp_path: Path):
     write_ssos_to_csv([], str(output))
 
     assert output.read_text(encoding="utf-8") == ""
+
+
+def test_write_ssos_to_csv_filelike():
+    buffer = StringIO()
+    records = [{"a": 1, "b": 2}]
+
+    write_ssos_to_csv_filelike(records, buffer)
+
+    buffer.seek(0)
+    reader = csv.DictReader(buffer)
+    rows = list(reader)
+    assert reader.fieldnames == ["a", "b"]
+    assert rows[0]["a"] == "1"

--- a/tests/test_webapp_api.py
+++ b/tests/test_webapp_api.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import List
+
+from fastapi.testclient import TestClient
+
+from sso_schema import (
+    COUNTY_FIELD,
+    START_DATE_FIELD,
+    UTILITY_ID_FIELD,
+    UTILITY_NAME_FIELD,
+    VOLUME_GALLONS_FIELD,
+)
+from webapp import api
+
+
+class DummyClient:
+    def __init__(self, records: List[dict]):
+        self.records = records
+
+    def fetch_ssos(self, query=None, limit=None, **kwargs):  # pragma: no cover - simple stub
+        if limit is not None:
+            return self.records[:limit]
+        return list(self.records)
+
+
+def _set_client_override(records: List[dict]) -> TestClient:
+    dummy = DummyClient(records)
+    api.app.dependency_overrides[api.get_client] = lambda: dummy
+    return TestClient(api.app)
+
+
+def _clear_overrides() -> None:
+    api.app.dependency_overrides = {}
+
+
+def test_health_check():
+    client = _set_client_override([])
+    response = client.get("/health")
+    _clear_overrides()
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "ok"
+
+
+def test_filters_endpoint_structure():
+    client = _set_client_override([])
+    response = client.get("/filters")
+    _clear_overrides()
+
+    payload = response.json()
+    assert "utilities" in payload
+    assert "counties" in payload
+    assert isinstance(payload["utilities"], list)
+    assert isinstance(payload["counties"], list)
+
+
+def test_download_returns_csv_and_filename(tmp_path):
+    records = [
+        {
+            UTILITY_ID_FIELD: "AL1234567",
+            UTILITY_NAME_FIELD: "Sample Utility",
+            COUNTY_FIELD: "Mobile",
+            START_DATE_FIELD: datetime(2024, 1, 1),
+            VOLUME_GALLONS_FIELD: 100.0,
+        }
+    ]
+    client = _set_client_override(records)
+
+    response = client.get("/download", params={"utility_id": "AL1234567"})
+    _clear_overrides()
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/csv")
+    disposition = response.headers["content-disposition"]
+    assert "AL1234567" in disposition
+    assert "attachment" in disposition
+    assert UTILITY_ID_FIELD in response.text
+    assert "Sample Utility" in response.text
+
+
+def test_download_requires_filters():
+    client = _set_client_override([])
+    response = client.get("/download")
+    _clear_overrides()
+
+    assert response.status_code == 400
+    assert "At least one filter" in response.json()["detail"]
+
+
+def test_summary_returns_overall_and_top_utilities():
+    records = [
+        {
+            UTILITY_ID_FIELD: "AL1234567",
+            UTILITY_NAME_FIELD: "Utility A",
+            COUNTY_FIELD: "Mobile",
+            START_DATE_FIELD: datetime(2024, 1, 1),
+            VOLUME_GALLONS_FIELD: 100.0,
+        },
+        {
+            UTILITY_ID_FIELD: "AL7654321",
+            UTILITY_NAME_FIELD: "Utility B",
+            COUNTY_FIELD: "Mobile",
+            START_DATE_FIELD: datetime(2024, 2, 1),
+            VOLUME_GALLONS_FIELD: 50.0,
+        },
+    ]
+    client = _set_client_override(records)
+
+    response = client.get("/summary", params={"utility_id": "AL1234567"})
+    _clear_overrides()
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert "overall" in payload
+    assert payload["overall"]["count"] >= 2
+    assert "top_utilities" in payload
+    assert isinstance(payload["top_utilities"], list)
+    assert payload["top_utilities"]

--- a/webapp/__init__.py
+++ b/webapp/__init__.py
@@ -1,0 +1,5 @@
+"""Thin web layer for SSO downloads and previews."""
+
+from .api import app, create_app
+
+__all__ = ["app", "create_app"]

--- a/webapp/api.py
+++ b/webapp/api.py
@@ -1,0 +1,191 @@
+"""FastAPI web layer for SSO downloads and previews."""
+from __future__ import annotations
+
+import io
+from dataclasses import asdict
+from datetime import datetime
+from pathlib import Path
+from typing import Optional
+
+from fastapi import Depends, FastAPI, HTTPException, Request
+from fastapi.responses import HTMLResponse, StreamingResponse
+from fastapi.templating import Jinja2Templates
+from pydantic import BaseModel, Field, field_validator
+
+from sso_analytics import summarize_overall_volume, top_utilities_by_volume
+from sso_client import SSOClient, SSOClientError
+from sso_export import write_ssos_to_csv_filelike
+from sso_schema import SSOQuery, normalize_sso_records
+
+app = FastAPI(title="SSO Downloader")
+
+TEMPLATE_DIR = Path(__file__).resolve().parent / "templates"
+templates = Jinja2Templates(directory=str(TEMPLATE_DIR))
+
+# TODO: Load from configuration or persisted metadata
+DEFAULT_UTILITIES = [
+    {"id": "AL0046744", "name": "Prichard Water Works"},
+    {"id": "AL0027561", "name": "Mobile Area Water & Sewer"},
+    {"id": "AL0063002", "name": "City of Fairhope"},
+]
+DEFAULT_COUNTIES = [
+    "Mobile",
+    "Baldwin",
+    "Montgomery",
+    "Jefferson",
+]
+
+
+class SSOQueryParams(BaseModel):
+    utility_id: Optional[str] = Field(default=None, alias="utility_id")
+    utility_name: Optional[str] = Field(default=None, alias="utility_name")
+    county: Optional[str] = None
+    start_date: Optional[str] = Field(
+        default=None, pattern=r"^\d{4}-\d{2}-\d{2}$", description="YYYY-MM-DD"
+    )
+    end_date: Optional[str] = Field(
+        default=None, pattern=r"^\d{4}-\d{2}-\d{2}$", description="YYYY-MM-DD"
+    )
+    limit: Optional[int] = Field(default=None, ge=1, le=50000)
+
+    @field_validator("start_date", "end_date")
+    def _validate_date(cls, value: Optional[str]):
+        if value is None:
+            return value
+        try:
+            datetime.strptime(value, "%Y-%m-%d")
+        except ValueError as exc:  # pragma: no cover - handled by pydantic already
+            raise ValueError("Dates must use YYYY-MM-DD format") from exc
+        return value
+
+    def _parse_date(self, value: Optional[str]):
+        if value is None:
+            return None
+        return datetime.strptime(value, "%Y-%m-%d").date()
+
+    def has_filters(self) -> bool:
+        return any(
+            [
+                self.utility_id,
+                self.utility_name,
+                self.county,
+                self.start_date,
+                self.end_date,
+            ]
+        )
+
+    def to_sso_query(self) -> SSOQuery:
+        return SSOQuery(
+            utility_id=self.utility_id,
+            utility_name=self.utility_name,
+            county=self.county,
+            start_date=self._parse_date(self.start_date),
+            end_date=self._parse_date(self.end_date),
+        )
+
+
+def get_client() -> SSOClient:
+    return SSOClient()
+
+
+def create_app() -> FastAPI:
+    return app
+
+
+@app.get("/health")
+def health_check() -> dict[str, str]:
+    return {"status": "ok"}
+
+
+@app.get("/filters")
+def list_filters() -> dict[str, object]:
+    return {"utilities": DEFAULT_UTILITIES, "counties": DEFAULT_COUNTIES}
+
+
+@app.get("/", response_class=HTMLResponse)
+def index(request: Request):
+    return templates.TemplateResponse("index.html", {"request": request})
+
+
+def _ensure_filters(params: SSOQueryParams) -> None:
+    if not params.has_filters():
+        raise HTTPException(
+            status_code=400,
+            detail="At least one filter (utility, county, or date range) is required.",
+        )
+
+
+def _build_filename(params: SSOQueryParams) -> str:
+    parts = ["ssos"]
+    if params.utility_id:
+        parts.append(params.utility_id)
+    elif params.utility_name:
+        parts.append(params.utility_name.replace(" ", "_"))
+    elif params.county:
+        parts.append(params.county.replace(" ", "_"))
+    else:
+        parts.append("all")
+
+    if params.start_date:
+        parts.append(params.start_date)
+    if params.end_date:
+        parts.append(params.end_date)
+    return "_".join(parts) + ".csv"
+
+
+@app.get("/download")
+def download_csv(
+    params: SSOQueryParams = Depends(),
+    client: SSOClient = Depends(get_client),
+):
+    _ensure_filters(params)
+    query = params.to_sso_query()
+    try:
+        query.validate()
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    try:
+        records = client.fetch_ssos(query=query, limit=params.limit)
+    except SSOClientError as exc:  # pragma: no cover - network errors are mocked in tests
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
+
+    buffer = io.StringIO()
+    write_ssos_to_csv_filelike(records, buffer)
+    buffer.seek(0)
+
+    headers = {
+        "Content-Disposition": f'attachment; filename="{_build_filename(params)}"'
+    }
+    return StreamingResponse(
+        iter([buffer.getvalue()]),
+        media_type="text/csv; charset=utf-8",
+        headers=headers,
+    )
+
+
+@app.get("/summary")
+def summary(
+    params: SSOQueryParams = Depends(),
+    client: SSOClient = Depends(get_client),
+):
+    _ensure_filters(params)
+    query = params.to_sso_query()
+    try:
+        query.validate()
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    try:
+        raw_records = client.fetch_ssos(query=query, limit=params.limit)
+    except SSOClientError as exc:  # pragma: no cover - network errors are mocked in tests
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
+
+    records_norm = normalize_sso_records(raw_records)
+    overall = summarize_overall_volume(records_norm)
+    top_util = top_utilities_by_volume(records_norm, n=5)
+
+    return {
+        "overall": asdict(overall),
+        "top_utilities": [asdict(item) for item in top_util],
+    }

--- a/webapp/templates/index.html
+++ b/webapp/templates/index.html
@@ -1,0 +1,121 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <title>SSO Downloader</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 2rem; }
+        label { display: block; margin-top: 1rem; }
+        select, input { padding: 0.5rem; width: 240px; }
+        button { margin-top: 1rem; padding: 0.5rem 1rem; }
+        #summary { margin-top: 1.5rem; white-space: pre-wrap; border: 1px solid #ddd; padding: 1rem; }
+    </style>
+</head>
+<body>
+    <h1>SSO Downloader</h1>
+    <p>Choose filters to download sanitary sewer overflow records as CSV.</p>
+
+    <form id="filters-form">
+        <label>
+            Utility
+            <select id="utility">
+                <option value="">-- any utility --</option>
+            </select>
+        </label>
+
+        <label>
+            County
+            <select id="county">
+                <option value="">-- any county --</option>
+            </select>
+        </label>
+
+        <label>
+            Start date
+            <input type="date" id="start_date" />
+        </label>
+
+        <label>
+            End date
+            <input type="date" id="end_date" />
+        </label>
+
+        <div>
+            <button type="button" id="download">Download CSV</button>
+            <button type="button" id="preview">Preview summary</button>
+        </div>
+    </form>
+
+    <div id="summary" aria-live="polite"></div>
+
+    <script>
+        async function loadFilters() {
+            const response = await fetch('/filters');
+            const data = await response.json();
+            const utilitySelect = document.getElementById('utility');
+            const countySelect = document.getElementById('county');
+
+            (data.utilities || []).forEach(item => {
+                const option = document.createElement('option');
+                option.value = item.id;
+                option.textContent = `${item.name} (${item.id})`;
+                utilitySelect.appendChild(option);
+            });
+
+            (data.counties || []).forEach(name => {
+                const option = document.createElement('option');
+                option.value = name;
+                option.textContent = name;
+                countySelect.appendChild(option);
+            });
+        }
+
+        function buildQueryParams() {
+            const params = new URLSearchParams();
+            const utility = document.getElementById('utility').value;
+            const county = document.getElementById('county').value;
+            const startDate = document.getElementById('start_date').value;
+            const endDate = document.getElementById('end_date').value;
+
+            if (utility) params.set('utility_id', utility);
+            if (county) params.set('county', county);
+            if (startDate) params.set('start_date', startDate);
+            if (endDate) params.set('end_date', endDate);
+
+            return params;
+        }
+
+        function ensureFilters(params) {
+            return params.has('utility_id') || params.has('county') || params.has('start_date') || params.has('end_date');
+        }
+
+        document.getElementById('download').addEventListener('click', () => {
+            const params = buildQueryParams();
+            if (!ensureFilters(params)) {
+                alert('Please select at least one filter (utility, county, or date range).');
+                return;
+            }
+            window.location.href = `/download?${params.toString()}`;
+        });
+
+        document.getElementById('preview').addEventListener('click', async () => {
+            const params = buildQueryParams();
+            const summaryEl = document.getElementById('summary');
+            summaryEl.textContent = 'Loading summary...';
+            if (!ensureFilters(params)) {
+                summaryEl.textContent = 'Please add at least one filter to preview a summary.';
+                return;
+            }
+            const response = await fetch(`/summary?${params.toString()}`);
+            if (!response.ok) {
+                summaryEl.textContent = 'Failed to load summary. Please check your filters.';
+                return;
+            }
+            const data = await response.json();
+            summaryEl.textContent = JSON.stringify(data, null, 2);
+        });
+
+        loadFilters();
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a FastAPI-based web layer with endpoints for health, filters, CSV download, and summaries plus a minimal HTML UI
- extend CSV export helpers to support file-like outputs and cover them with tests
- document the web UI/API usage and list the new web dependencies

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f75a06bdc832b8b007e73ebf018ff)