### PR TITLE
Add interactive dashboard endpoints and UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,27 @@ A lightweight FastAPI layer is available for quick filtered downloads and previe
 
 This module is intended as a thin shell that future dashboards (Module G) can extend without re-implementing query or CSV logic.
 
+### Interactive dashboard (Module G)
+
+Module G layers a human-friendly dashboard on top of the existing FastAPI app and analytics helpers.
+
+- **Run locally:** `uvicorn webapp.api:app --reload` and open `http://127.0.0.1:8000/dashboard`.
+- **Features:**
+  - Filters for utility, county, and date range (with optional record limit).
+  - Summary cards for total spills and volume statistics.
+  - Charts for spills over time and volume by utility (Chart.js via CDN).
+  - Tabular record view with the same filters applied.
+  - CSV download button that reuses the `/download` endpoint.
+- **Dashboard API endpoints:**
+  - `/filters` – utility and county options for form controls.
+  - `/summary` – overall volume metrics and top utilities.
+  - `/series/by_date` – time series JSON for charts (`points` with date, count, total_volume_gallons).
+  - `/series/by_utility` – grouped bar data by utility (`bars` with label, count, total_volume_gallons).
+  - `/records` – normalized record list for the table view.
+  - `/download` – CSV export for the current filters.
+
+Module G is UI-only: it reuses Modules A–F for querying, normalization, CSV export, and analytics without adding new data sources.
+
 The legacy Playwright-based downloader/parser scripts remain available below but are treated as legacy compared to the ArcGIS path above.
 
 ## Repository layout and entry points

--- a/tests/test_webapp_api.py
+++ b/tests/test_webapp_api.py
@@ -5,6 +5,11 @@ from typing import List
 
 from fastapi.testclient import TestClient
 
+from datetime import datetime
+from typing import List
+
+from fastapi.testclient import TestClient
+
 from sso_schema import (
     COUNTY_FIELD,
     START_DATE_FIELD,

--- a/tests/test_webapp_series.py
+++ b/tests/test_webapp_series.py
@@ -1,0 +1,118 @@
+from datetime import datetime
+from typing import List
+
+from fastapi.testclient import TestClient
+
+from sso_schema import (
+    COUNTY_FIELD,
+    START_DATE_FIELD,
+    UTILITY_NAME_FIELD,
+    VOLUME_GALLONS_FIELD,
+)
+from webapp import api
+
+
+class DummyClient:
+    def __init__(self, records: List[dict]):
+        self.records = records
+        self.last_limit = None
+
+    def fetch_ssos(self, query=None, limit=None, **kwargs):
+        self.last_limit = limit
+        if limit is not None:
+            return list(self.records)[:limit]
+        return list(self.records)
+
+
+def _set_client_override(records: List[dict]) -> TestClient:
+    dummy = DummyClient(records)
+    api.app.dependency_overrides[api.get_client] = lambda: dummy
+    return TestClient(api.app), dummy
+
+
+def _clear_overrides() -> None:
+    api.app.dependency_overrides = {}
+
+
+def test_series_by_date_returns_points_and_enforces_limit():
+    records = [
+        {START_DATE_FIELD: datetime(2024, 1, 1), VOLUME_GALLONS_FIELD: 100.0},
+        {START_DATE_FIELD: datetime(2024, 1, 1), VOLUME_GALLONS_FIELD: 50.0},
+        {START_DATE_FIELD: datetime(2024, 1, 2), VOLUME_GALLONS_FIELD: 75.0},
+    ]
+    client, dummy = _set_client_override(records)
+
+    response = client.get("/series/by_date", params={"start_date": "2024-01-01"})
+    _clear_overrides()
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert "points" in payload
+    assert payload["points"][0]["date"] == "2024-01-01"
+    assert payload["points"][0]["count"] == 2
+    assert dummy.last_limit == 5000  # default bounded limit
+
+
+def test_series_by_utility_returns_bars():
+    records = [
+        {
+            START_DATE_FIELD: datetime(2024, 1, 1),
+            UTILITY_NAME_FIELD: "Utility A",
+            VOLUME_GALLONS_FIELD: 100.0,
+        },
+        {
+            START_DATE_FIELD: datetime(2024, 1, 2),
+            UTILITY_NAME_FIELD: "Utility B",
+            VOLUME_GALLONS_FIELD: 50.0,
+        },
+        {
+            START_DATE_FIELD: datetime(2024, 1, 3),
+            UTILITY_NAME_FIELD: "Utility A",
+            VOLUME_GALLONS_FIELD: 25.0,
+        },
+    ]
+    client, dummy = _set_client_override(records)
+
+    response = client.get("/series/by_utility", params={"county": "Mobile", "limit": 20000})
+    _clear_overrides()
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert "bars" in payload
+    labels = [bar["label"] for bar in payload["bars"]]
+    assert "Utility A" in labels
+    assert dummy.last_limit == 10000  # capped at maximum
+
+
+def test_records_endpoint_returns_serialized_rows():
+    records = [
+        {
+            START_DATE_FIELD: datetime(2024, 1, 1),
+            UTILITY_NAME_FIELD: "Utility A",
+            COUNTY_FIELD: "Mobile",
+            VOLUME_GALLONS_FIELD: 100.0,
+        }
+    ]
+    client, dummy = _set_client_override(records)
+
+    response = client.get(
+        "/records", params={"utility_name": "Utility A", "limit": 5, "offset": 0}
+    )
+    _clear_overrides()
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert "records" in payload
+    assert payload["records"][0]["utility_name"] == "Utility A"
+    assert payload["total"] == 1
+    assert dummy.last_limit == 5
+
+
+def test_dashboard_template_renders():
+    client, _dummy = _set_client_override([])
+    response = client.get("/dashboard")
+    _clear_overrides()
+
+    assert response.status_code == 200
+    assert "summary-total-count" in response.text
+    assert "time-series-chart" in response.text

--- a/webapp/api.py
+++ b/webapp/api.py
@@ -9,10 +9,16 @@ from typing import Optional
 
 from fastapi import Depends, FastAPI, HTTPException, Request
 from fastapi.responses import HTMLResponse, StreamingResponse
+from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 from pydantic import BaseModel, Field, field_validator
 
-from sso_analytics import summarize_overall_volume, top_utilities_by_volume
+from sso_analytics import (
+    summarize_overall_volume,
+    summarize_volume_by_utility,
+    top_utilities_by_volume,
+    time_series_by_date,
+)
 from sso_client import SSOClient, SSOClientError
 from sso_export import write_ssos_to_csv_filelike
 from sso_schema import SSOQuery, normalize_sso_records
@@ -20,7 +26,9 @@ from sso_schema import SSOQuery, normalize_sso_records
 app = FastAPI(title="SSO Downloader")
 
 TEMPLATE_DIR = Path(__file__).resolve().parent / "templates"
+STATIC_DIR = Path(__file__).resolve().parent / "static"
 templates = Jinja2Templates(directory=str(TEMPLATE_DIR))
+app.mount("/static", StaticFiles(directory=str(STATIC_DIR)), name="static")
 
 # TODO: Load from configuration or persisted metadata
 DEFAULT_UTILITIES = [
@@ -83,6 +91,13 @@ class SSOQueryParams(BaseModel):
             end_date=self._parse_date(self.end_date),
         )
 
+    def bounded_limit(self, *, default: int, maximum: int) -> int:
+        """Return a safe limit based on provided value and bounds."""
+
+        if self.limit is None:
+            return min(default, maximum)
+        return min(self.limit, maximum)
+
 
 def get_client() -> SSOClient:
     return SSOClient()
@@ -104,7 +119,7 @@ def list_filters() -> dict[str, object]:
 
 @app.get("/", response_class=HTMLResponse)
 def index(request: Request):
-    return templates.TemplateResponse("index.html", {"request": request})
+    return templates.TemplateResponse(request, "index.html", {"request": request})
 
 
 def _ensure_filters(params: SSOQueryParams) -> None:
@@ -189,3 +204,126 @@ def summary(
         "overall": asdict(overall),
         "top_utilities": [asdict(item) for item in top_util],
     }
+
+
+@app.get("/series/by_date")
+def series_by_date(
+    params: SSOQueryParams = Depends(),
+    client: SSOClient = Depends(get_client),
+):
+    _ensure_filters(params)
+    query = params.to_sso_query()
+    try:
+        query.validate()
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    safe_limit = params.bounded_limit(default=5000, maximum=10000)
+
+    try:
+        raw_records = client.fetch_ssos(query=query, limit=safe_limit)
+    except SSOClientError as exc:  # pragma: no cover - network errors are mocked in tests
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
+
+    records_norm = normalize_sso_records(raw_records)
+    series = time_series_by_date(records_norm)
+
+    return {"points": [asdict(point) for point in series]}
+
+
+@app.get("/series/by_utility")
+def series_by_utility(
+    params: SSOQueryParams = Depends(),
+    client: SSOClient = Depends(get_client),
+):
+    _ensure_filters(params)
+    query = params.to_sso_query()
+    try:
+        query.validate()
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    safe_limit = params.bounded_limit(default=5000, maximum=10000)
+
+    try:
+        raw_records = client.fetch_ssos(query=query, limit=safe_limit)
+    except SSOClientError as exc:  # pragma: no cover - network errors are mocked in tests
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
+
+    records_norm = normalize_sso_records(raw_records)
+    grouped = summarize_volume_by_utility(records_norm)
+    counts: dict[str, int] = {}
+    for record in records_norm:
+        if record.utility_name:
+            counts[record.utility_name] = counts.get(record.utility_name, 0) + 1
+
+    bars = [
+        {
+            "label": item.group_key,
+            "count": counts.get(item.group_key, item.count),
+            "total_volume_gallons": item.total_volume_gallons,
+        }
+        for item in grouped
+    ]
+    return {"bars": bars}
+
+
+class RecordsQueryParams(SSOQueryParams):
+    offset: int = Field(default=0, ge=0)
+    limit: Optional[int] = Field(default=200, ge=1, le=10000)
+
+
+def _serialize_record(record) -> dict[str, object]:
+    return {
+        "id": record.sso_id,
+        "utility_id": record.utility_id,
+        "utility_name": record.utility_name,
+        "county": record.county,
+        "date_sso_began": record.date_sso_began.isoformat()
+        if record.date_sso_began
+        else None,
+        "date_sso_stopped": record.date_sso_stopped.isoformat()
+        if record.date_sso_stopped
+        else None,
+        "volume_gallons": record.volume_gallons,
+        "cause": record.cause,
+        "receiving_water": record.receiving_water,
+        "address": record.location_desc,
+        "x": record.x,
+        "y": record.y,
+    }
+
+
+@app.get("/records")
+def list_records(
+    params: RecordsQueryParams = Depends(),
+    client: SSOClient = Depends(get_client),
+):
+    _ensure_filters(params)
+    query = params.to_sso_query()
+    try:
+        query.validate()
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    safe_limit = params.bounded_limit(default=500, maximum=1000)
+
+    try:
+        raw_records = client.fetch_ssos(query=query, limit=safe_limit + params.offset)
+    except SSOClientError as exc:  # pragma: no cover - network errors are mocked in tests
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
+
+    normalized = normalize_sso_records(raw_records)
+    sliced = normalized[params.offset : params.offset + safe_limit]
+
+    return {
+        "records": [_serialize_record(record) for record in sliced],
+        "total": len(normalized),
+        "offset": params.offset,
+        "limit": safe_limit,
+    }
+
+
+@app.get("/dashboard", response_class=HTMLResponse)
+def dashboard(request: Request):
+    return templates.TemplateResponse(request, "dashboard.html", {"request": request})

--- a/webapp/static/dashboard.js
+++ b/webapp/static/dashboard.js
@@ -1,0 +1,266 @@
+(function () {
+  const state = {
+    timeSeriesChart: null,
+    utilityChart: null,
+  };
+
+  function setStatus(message, isError = false) {
+    const el = document.getElementById('status');
+    if (!el) return;
+    el.textContent = message || '';
+    el.style.color = isError ? '#b91c1c' : '#374151';
+  }
+
+  function formatNumber(value) {
+    if (value === null || value === undefined) return '–';
+    if (isNaN(value)) return String(value);
+    return Number(value).toLocaleString(undefined, { maximumFractionDigits: 1 });
+  }
+
+  function buildQueryParams() {
+    const params = new URLSearchParams();
+    const utility = document.getElementById('utility-select').value;
+    const county = document.getElementById('county-select').value;
+    const startDate = document.getElementById('start-date').value;
+    const endDate = document.getElementById('end-date').value;
+    const limit = document.getElementById('record-limit').value;
+
+    if (utility) params.set('utility_id', utility);
+    if (county) params.set('county', county);
+    if (startDate) params.set('start_date', startDate);
+    if (endDate) params.set('end_date', endDate);
+    if (limit) params.set('limit', limit);
+    return params;
+  }
+
+  function ensureFilters(params) {
+    return (
+      params.has('utility_id') ||
+      params.has('county') ||
+      params.has('start_date') ||
+      params.has('end_date')
+    );
+  }
+
+  async function fetchJson(url) {
+    const response = await fetch(url);
+    if (!response.ok) {
+      throw new Error(`Request failed (${response.status})`);
+    }
+    return response.json();
+  }
+
+  async function loadFilters() {
+    try {
+      const data = await fetchJson('/filters');
+      const utilitySelect = document.getElementById('utility-select');
+      const countySelect = document.getElementById('county-select');
+
+      (data.utilities || []).forEach((item) => {
+        const option = document.createElement('option');
+        option.value = item.id;
+        option.textContent = `${item.name} (${item.id})`;
+        utilitySelect.appendChild(option);
+      });
+
+      (data.counties || []).forEach((name) => {
+        const option = document.createElement('option');
+        option.value = name;
+        option.textContent = name;
+        countySelect.appendChild(option);
+      });
+    } catch (err) {
+      setStatus('Unable to load filters.', true);
+    }
+  }
+
+  function setDefaultDates() {
+    const end = new Date();
+    const start = new Date();
+    start.setMonth(start.getMonth() - 6);
+    document.getElementById('end-date').value = end.toISOString().slice(0, 10);
+    document.getElementById('start-date').value = start.toISOString().slice(0, 10);
+  }
+
+  function renderSummary(data) {
+    const overall = data.overall || {};
+    document.getElementById('summary-total-count').textContent = formatNumber(
+      overall.count
+    );
+    document.getElementById('summary-total-volume').textContent = formatNumber(
+      overall.total_volume_gallons
+    );
+    document.getElementById('summary-avg-volume').textContent = formatNumber(
+      overall.mean_volume_gallons
+    );
+    document.getElementById('summary-max-volume').textContent = formatNumber(
+      overall.max_volume_gallons
+    );
+  }
+
+  function renderTimeSeries(points) {
+    const ctx = document.getElementById('time-series-chart');
+    if (!ctx) return;
+    const labels = points.map((p) => p.date);
+    const counts = points.map((p) => p.count);
+    const volumes = points.map((p) => p.total_volume_gallons);
+
+    if (state.timeSeriesChart) {
+      state.timeSeriesChart.data.labels = labels;
+      state.timeSeriesChart.data.datasets[0].data = counts;
+      state.timeSeriesChart.data.datasets[1].data = volumes;
+      state.timeSeriesChart.update();
+      return;
+    }
+
+    state.timeSeriesChart = new Chart(ctx, {
+      type: 'line',
+      data: {
+        labels,
+        datasets: [
+          {
+            label: 'Spills',
+            data: counts,
+            borderColor: '#2563eb',
+            backgroundColor: 'rgba(37,99,235,0.1)',
+            tension: 0.2,
+            yAxisID: 'y',
+          },
+          {
+            label: 'Total volume (gal)',
+            data: volumes,
+            borderColor: '#10b981',
+            backgroundColor: 'rgba(16,185,129,0.1)',
+            tension: 0.2,
+            yAxisID: 'y1',
+          },
+        ],
+      },
+      options: {
+        scales: {
+          y: {
+            position: 'left',
+            title: { display: true, text: 'Spills' },
+          },
+          y1: {
+            position: 'right',
+            grid: { drawOnChartArea: false },
+            title: { display: true, text: 'Volume (gal)' },
+          },
+        },
+        plugins: {
+          legend: { position: 'bottom' },
+        },
+      },
+    });
+  }
+
+  function renderUtilityBars(bars) {
+    const ctx = document.getElementById('utility-chart');
+    if (!ctx) return;
+    const labels = bars.map((b) => b.label);
+    const volumes = bars.map((b) => b.total_volume_gallons);
+
+    if (state.utilityChart) {
+      state.utilityChart.data.labels = labels;
+      state.utilityChart.data.datasets[0].data = volumes;
+      state.utilityChart.update();
+      return;
+    }
+
+    state.utilityChart = new Chart(ctx, {
+      type: 'bar',
+      data: {
+        labels,
+        datasets: [
+          {
+            label: 'Total volume (gal)',
+            data: volumes,
+            backgroundColor: '#2563eb',
+          },
+        ],
+      },
+      options: {
+        indexAxis: 'y',
+        plugins: {
+          legend: { display: false },
+        },
+      },
+    });
+  }
+
+  function renderTable(records) {
+    const tbody = document.getElementById('records-table-body');
+    tbody.innerHTML = '';
+    if (!records || records.length === 0) {
+      const row = document.createElement('tr');
+      const cell = document.createElement('td');
+      cell.colSpan = 6;
+      cell.textContent = 'No records found for the selected filters.';
+      row.appendChild(cell);
+      tbody.appendChild(row);
+      return;
+    }
+
+    records.forEach((record) => {
+      const row = document.createElement('tr');
+      const cells = [
+        record.date_sso_began ? record.date_sso_began.slice(0, 10) : '–',
+        record.utility_name || '–',
+        record.county || '–',
+        formatNumber(record.volume_gallons),
+        record.cause || '–',
+        record.receiving_water || '–',
+      ];
+      cells.forEach((value) => {
+        const cell = document.createElement('td');
+        cell.textContent = value;
+        row.appendChild(cell);
+      });
+      tbody.appendChild(row);
+    });
+  }
+
+  async function refreshDashboard() {
+    const params = buildQueryParams();
+    if (!ensureFilters(params)) {
+      setStatus('Please add at least one filter (utility, county, or date range).', true);
+      return;
+    }
+    setStatus('Loading...');
+    const query = params.toString();
+    try {
+      const [summary, seriesDate, seriesUtility, records] = await Promise.all([
+        fetchJson(`/summary?${query}`),
+        fetchJson(`/series/by_date?${query}`),
+        fetchJson(`/series/by_utility?${query}`),
+        fetchJson(`/records?${query}`),
+      ]);
+      renderSummary(summary);
+      renderTimeSeries(seriesDate.points || []);
+      renderUtilityBars(seriesUtility.bars || []);
+      renderTable(records.records || []);
+      setStatus('');
+    } catch (err) {
+      setStatus('Failed to load dashboard data. Please adjust filters and try again.', true);
+    }
+  }
+
+  function wireEvents() {
+    document.getElementById('apply-filters').addEventListener('click', refreshDashboard);
+    document.getElementById('download-csv').addEventListener('click', () => {
+      const params = buildQueryParams();
+      if (!ensureFilters(params)) {
+        setStatus('Please add at least one filter to download.', true);
+        return;
+      }
+      window.location.href = `/download?${params.toString()}`;
+    });
+  }
+
+  document.addEventListener('DOMContentLoaded', async () => {
+    setDefaultDates();
+    await loadFilters();
+    wireEvents();
+  });
+})();

--- a/webapp/templates/dashboard.html
+++ b/webapp/templates/dashboard.html
@@ -1,0 +1,109 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <title>SSO Dashboard</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/modern-css-reset@1.4.0/dist/reset.min.css" />
+    <style>
+        body { font-family: Arial, sans-serif; margin: 1.5rem; background: #f7f7f7; }
+        h1 { margin-bottom: 0.5rem; }
+        .layout { display: grid; grid-template-columns: 280px 1fr; gap: 1.5rem; align-items: start; }
+        .panel { background: #fff; border: 1px solid #e2e2e2; border-radius: 8px; padding: 1rem; box-shadow: 0 1px 2px rgba(0,0,0,0.05); }
+        .panel h2 { margin: 0 0 0.5rem 0; font-size: 1.1rem; }
+        label { display: block; margin-top: 0.75rem; font-weight: 600; }
+        select, input { width: 100%; padding: 0.55rem; margin-top: 0.35rem; border: 1px solid #ccc; border-radius: 4px; }
+        button { padding: 0.6rem 0.9rem; border: none; border-radius: 4px; cursor: pointer; font-weight: 600; }
+        #apply-filters { background: #2563eb; color: #fff; }
+        #download-csv { background: #065f46; color: #fff; margin-left: 0.5rem; }
+        .button-row { margin-top: 1rem; display: flex; flex-wrap: wrap; gap: 0.5rem; }
+        .cards { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 0.75rem; }
+        .card { background: #fff; padding: 0.75rem 1rem; border-radius: 8px; border: 1px solid #e5e7eb; box-shadow: 0 1px 2px rgba(0,0,0,0.04); }
+        .card-title { color: #6b7280; font-size: 0.85rem; }
+        .card-value { font-size: 1.4rem; font-weight: bold; margin-top: 0.35rem; }
+        .charts { display: grid; grid-template-columns: repeat(auto-fit, minmax(320px, 1fr)); gap: 1rem; margin-top: 1rem; }
+        .table-container { overflow-x: auto; margin-top: 1rem; }
+        table { width: 100%; border-collapse: collapse; font-size: 0.9rem; }
+        th, td { padding: 0.6rem; border-bottom: 1px solid #e5e7eb; text-align: left; }
+        th { background: #f3f4f6; font-weight: 700; }
+        #status { margin-top: 0.75rem; color: #b91c1c; }
+    </style>
+</head>
+<body>
+    <header>
+        <h1>Sanitary Sewer Overflow Dashboard</h1>
+        <p>Explore SSO reports with filters, summaries, charts, and record details.</p>
+    </header>
+    <div class="layout">
+        <aside class="panel">
+            <h2>Filters</h2>
+            <label for="utility-select">Utility</label>
+            <select id="utility-select">
+                <option value="">Any utility</option>
+            </select>
+            <label for="county-select">County</label>
+            <select id="county-select">
+                <option value="">Any county</option>
+            </select>
+            <label for="start-date">Start date</label>
+            <input type="date" id="start-date" />
+            <label for="end-date">End date</label>
+            <input type="date" id="end-date" />
+            <label for="record-limit">Max records</label>
+            <input type="number" id="record-limit" min="1" max="1000" value="200" />
+            <div class="button-row">
+                <button id="apply-filters">Apply filters</button>
+                <button id="download-csv">Download CSV</button>
+            </div>
+            <div id="status" aria-live="polite"></div>
+        </aside>
+        <main>
+            <section class="cards" aria-live="polite">
+                <div class="card">
+                    <div class="card-title">Total spills</div>
+                    <div class="card-value" id="summary-total-count">–</div>
+                </div>
+                <div class="card">
+                    <div class="card-title">Total volume (gal)</div>
+                    <div class="card-value" id="summary-total-volume">–</div>
+                </div>
+                <div class="card">
+                    <div class="card-title">Average volume (gal)</div>
+                    <div class="card-value" id="summary-avg-volume">–</div>
+                </div>
+                <div class="card">
+                    <div class="card-title">Max volume (gal)</div>
+                    <div class="card-value" id="summary-max-volume">–</div>
+                </div>
+            </section>
+            <section class="charts">
+                <div class="panel">
+                    <h2>Spills over time</h2>
+                    <canvas id="time-series-chart"></canvas>
+                </div>
+                <div class="panel">
+                    <h2>Volume by utility</h2>
+                    <canvas id="utility-chart"></canvas>
+                </div>
+            </section>
+            <section class="panel table-container">
+                <h2>Matching records</h2>
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Date began</th>
+                            <th>Utility</th>
+                            <th>County</th>
+                            <th>Volume (gal)</th>
+                            <th>Cause</th>
+                            <th>Receiving water</th>
+                        </tr>
+                    </thead>
+                    <tbody id="records-table-body"></tbody>
+                </table>
+            </section>
+        </main>
+    </div>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script src="{{ url_for('static', path='dashboard.js') }}"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add dashboard-friendly API endpoints for time series, utility grouping, and record listings
- build a new /dashboard page with filters, summary cards, charts, and table powered by existing analytics
- document Module G usage and add tests for the new endpoints and template

## Testing
- python -m pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f7714a36c832b88112eb7e4c6968d)