### PR TITLE
Add analytics summary endpoint and dashboard aggregations

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ A lightweight FastAPI layer is available for quick filtered downloads and previe
 - **Endpoints:**
   - `/` – minimal HTML UI with dropdowns for utility/county and date range inputs
   - `/download` – CSV download for the selected filters
-  - `/summary` – brief JSON volume summary (uses `sso_analytics` helpers)
+  - `/api/ssos/summary` – dashboard-ready aggregate JSON (with `/summary` as a legacy alias)
   - `/filters` – metadata for populating UI dropdowns
 - **Config:** honors the same `SSO_API_BASE_URL`, `SSO_API_KEY`, and `SSO_API_TIMEOUT` env vars used by the CLI.
 
@@ -78,7 +78,7 @@ Module G layers a human-friendly dashboard on top of the existing FastAPI app an
   - CSV download button that reuses the `/download` endpoint.
 - **Dashboard API endpoints:**
   - `/filters` – utility and county options for form controls.
-  - `/summary` – overall volume metrics and top utilities.
+  - `/api/ssos/summary` – aggregate metrics (totals plus by-month, by-utility, and volume buckets).
   - `/series/by_date` – time series JSON for charts (`points` with date, count, total_volume_gallons).
   - `/series/by_utility` – grouped bar data by utility (`bars` with label, count, total_volume_gallons).
   - `/records` – normalized record list for the table view.

--- a/tests/test_webapp_api.py
+++ b/tests/test_webapp_api.py
@@ -94,7 +94,7 @@ def test_download_requires_filters():
     assert "At least one filter" in response.json()["detail"]
 
 
-def test_summary_returns_overall_and_top_utilities():
+def test_dashboard_summary_returns_expected_payload():
     records = [
         {
             UTILITY_ID_FIELD: "AL1234567",
@@ -113,13 +113,13 @@ def test_summary_returns_overall_and_top_utilities():
     ]
     client = _set_client_override(records)
 
-    response = client.get("/summary", params={"utility_id": "AL1234567"})
+    response = client.get("/api/ssos/summary", params={"utility_id": "AL1234567"})
     _clear_overrides()
 
     assert response.status_code == 200
     payload = response.json()
-    assert "overall" in payload
-    assert payload["overall"]["count"] >= 2
-    assert "top_utilities" in payload
-    assert isinstance(payload["top_utilities"], list)
-    assert payload["top_utilities"]
+    assert payload["summary_counts"]["total_records"] == 2
+    assert payload["summary_counts"]["total_volume"] == 150.0
+    assert payload["by_month"]
+    assert payload["by_utility"]
+    assert payload["by_volume_bucket"]


### PR DESCRIPTION
## Summary
- add reusable aggregation helpers for dashboard metrics (by month, utility, and volume bucket)
- provide a consolidated dashboard summary payload builder for UI consumption
- expose a new `/api/ssos/summary` endpoint (with legacy `/summary` alias) and document the updated API

## Testing
- pytest tests/test_sso_analytics.py
- pytest *(fails: missing requests/fastapi dependencies in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f7ac78ac8832b90da0583ec246c20)