### PR TITLE
Fix docs link and clean up summaries

### DIFF
--- a/sso_download.py
+++ b/sso_download.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import argparse
 import sys
 from datetime import datetime
-from typing import Iterable
+from typing import Dict, List
 
 from sso_analytics import QAIssue, run_basic_qa, summarize_overall_volume, summarize_volume_by_utility
 from sso_schema import normalize_sso_records
@@ -75,8 +75,8 @@ def _ensure_filters_present(args: argparse.Namespace) -> None:
         )
 
 
-def _summarize(records: Iterable[dict], output_path: str, limit: int | None) -> None:
-    count = len(list(records)) if not isinstance(records, list) else len(records)
+def _summarize(records: List[Dict], output_path: str, limit: int | None) -> None:
+    count = len(records)
     message_parts = [f"Fetched {count} records"]
     if limit is not None and count >= limit:
         message_parts.append("(truncated by --limit)")

--- a/webapp/static/dashboard.js
+++ b/webapp/static/dashboard.js
@@ -310,10 +310,9 @@
     tbody.innerHTML = '';
 
     const records = response.items || response.records || [];
-    const total = response.total || records.length;
     const limit = response.limit || records.length;
 
-    tableMeta.textContent = `Showing ${records.length} of ${total} records (limit ${limit})`;
+    tableMeta.textContent = `Showing ${records.length} records (limit ${limit})`;
 
     if (!records.length) {
       const row = document.createElement('tr');

--- a/webapp/templates/dashboard.html
+++ b/webapp/templates/dashboard.html
@@ -53,7 +53,7 @@
         <nav>
             <a href="/dashboard">Dashboard</a>
             <a href="/">Download</a>
-            <a href="/api/docs">API docs</a>
+            <a href="/docs">API docs</a>
         </nav>
     </header>
     <main>


### PR DESCRIPTION
## Summary
- Update the dashboard API docs link to match the FastAPI docs location
- Make the dashboard table meta accurately describe the displayed records
- Simplify CLI summarization to avoid rematerializing record collections

## Testing
- pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693059e7bfe0832bad7a660057228551)