### PR TITLE
Normalize estimated volume buckets and update summaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ The repository now includes a reusable client and CLI that query ADEM's ArcGIS R
 - **CLI:** `sso_download.py` uses the client and exporter to pull data from the ArcGIS API.
 - **Analytics and QA:** `sso_analytics.py` computes reusable summaries (totals by utility, county, or month), top-N helpers, and basic QA checks for missing fields or odd volume text. These helpers operate on normalized `SSORecord` objects from `sso_schema.py` and can be used by the CLI or future dashboards.
 
+Volume fields are normalized automatically: the raw `est_volume` string from ADEM is preserved, while structured columns `est_volume_gal` (upper bound for bucketed ranges), `est_volume_is_range` (`Y/N`), and `est_volume_range_label` are added to CSV exports. Summaries and averages use `est_volume_gal`, so bucketed values contribute their upper bound to totals.
+
 Configuration:
 
 - `SSO_API_BASE_URL`: Override the ArcGIS query endpoint (defaults to `https://gis.adem.alabama.gov/arcgis/rest/services/SSOs_ALL_OB_ID/MapServer/0/query`).

--- a/docs/schema_and_filters.md
+++ b/docs/schema_and_filters.md
@@ -8,9 +8,11 @@ Module `sso_schema.py` centralizes how the ArcGIS REST SSO records are represent
 
 - Identity and utility: `sso_id`, `utility_id` (permit number), `utility_name`, `sewer_system`, `county`, `location_desc`
 - Timing: `date_sso_began`, `date_sso_stopped` as `datetime`
-- Magnitude and impact: `volume_gallons`, `cause`, `receiving_water`
+- Magnitude and impact: `volume_gallons`, `est_volume`, `est_volume_gal` (numeric upper bound for bucketed estimates), `est_volume_is_range`, `est_volume_range_label`, `cause`, `receiving_water`
 - Coordinates: `x`, `y`
 - `raw`: the full original record dictionary for any extra fields
+
+Bucketed estimated volumes such as ``"10,000 < gall"`` are mapped to a numeric estimate using the upper bound of the bucket, and the original string is preserved on ``est_volume``. Summaries and averages therefore include bucketed spills instead of dropping them as non-numeric text.
 
 Use `normalize_sso_record` to convert a single raw ArcGIS feature (attributes + geometry) to an `SSORecord`, or `normalize_sso_records` to process a collection. The helpers are defensive and return `None` for fields that cannot be parsed instead of raising.
 

--- a/sso_download.py
+++ b/sso_download.py
@@ -8,6 +8,7 @@ from typing import Dict, List
 
 from sso_analytics import QAIssue, run_basic_qa, summarize_overall_volume, summarize_volume_by_utility
 from sso_schema import normalize_sso_records
+from sso_volume import enrich_est_volume_fields
 
 from sso_client import SSOClient, SSOClientError
 from sso_export import write_ssos_to_csv
@@ -163,6 +164,9 @@ def main(argv: list[str] | None = None) -> int:
     if not records:
         print("No records returned for the given filters.")
         return 0
+
+    for record in records:
+        enrich_est_volume_fields(record)
 
     records_norm = normalize_sso_records(records)
     write_ssos_to_csv(records, args.output)

--- a/sso_volume.py
+++ b/sso_volume.py
@@ -1,0 +1,102 @@
+"""Helpers for parsing and normalizing estimated volume fields."""
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any, Dict, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+
+def _normalize_raw_value(raw: str) -> str:
+    """Return a normalized representation for mapping lookups."""
+
+    return re.sub(r"\s+", "", raw).lower()
+
+
+_BUCKET_MAPPINGS = {
+    "<=1,0": (0, 1_000),
+    "<=1,000": (0, 1_000),
+    "<=1000": (0, 1_000),
+    "1,000<gall": (1_000, 10_000),
+    "1000<gall": (1_000, 10_000),
+    "10,000<gall": (10_000, 25_000),
+    "10000<gall": (10_000, 25_000),
+    "25,000<gall": (25_000, 50_000),
+    "25000<gall": (25_000, 50_000),
+    "50,000<gall": (50_000, 75_000),
+    "50000<gall": (50_000, 75_000),
+    "75,000<gall": (75_000, 100_000),
+    "75000<gall": (75_000, 100_000),
+    "75,000<gallo": (75_000, 100_000),
+    "100,000<gall": (100_000, 250_000),
+    "100000<gall": (100_000, 250_000),
+    "250,000<gall": (250_000, 500_000),
+    "250000<gall": (250_000, 500_000),
+    "500,000<gall": (500_000, 750_000),
+    "500000<gall": (500_000, 750_000),
+    "750,000<gall": (750_000, 1_000_000),
+    "750,000<gallo": (750_000, 1_000_000),
+    "750000<gall": (750_000, 1_000_000),
+}
+
+
+def _bucket_label(lower: int, upper: Optional[int]) -> str:
+    if upper is None:
+        return f"\u2265 {lower:,}"
+    if lower == 0:
+        return f"0 - {upper:,}"
+    return f"{lower:,} - {upper:,}"
+
+
+def parse_est_volume(raw: Any) -> Tuple[Optional[int], bool, Optional[str]]:
+    """Parse a raw estimated volume string into structured pieces.
+
+    Returns a tuple of ``(est_volume_gal, is_range, range_label)`` where
+    ``est_volume_gal`` represents the numeric estimate (upper bound for ranges).
+    """
+
+    if raw is None:
+        return None, False, None
+
+    try:
+        raw_str = str(raw).strip()
+    except Exception:  # pragma: no cover - extremely defensive
+        return None, False, None
+
+    if not raw_str:
+        return None, False, None
+
+    if re.fullmatch(r"[\d,\s]+", raw_str):
+        return int(raw_str.replace(",", "")), False, None
+
+    norm = _normalize_raw_value(raw_str)
+    if norm in _BUCKET_MAPPINGS:
+        lower, upper = _BUCKET_MAPPINGS[norm]
+        return upper, True, _bucket_label(lower, upper)
+
+    for key, (lower, upper) in _BUCKET_MAPPINGS.items():
+        if norm.startswith(key):
+            return upper, True, _bucket_label(lower, upper)
+
+    numbers = [int(value.replace(",", "")) for value in re.findall(r"\d[\d,]*", raw_str)]
+    if len(numbers) >= 2:
+        lower, upper = numbers[0], numbers[1]
+        return upper, True, _bucket_label(lower, upper)
+    if len(numbers) == 1:
+        lower = numbers[0]
+        return lower, True, _bucket_label(lower, None)
+
+    logger.warning("Unrecognized estimated volume format: %s", raw_str)
+    return None, True, raw_str
+
+
+def enrich_est_volume_fields(record: Dict[str, Any]) -> None:
+    """Add structured estimated volume fields onto a raw record dictionary."""
+
+    raw_est_volume = record.get("est_volume")
+    est_volume_gal, is_range, range_label = parse_est_volume(raw_est_volume)
+
+    record["est_volume_gal"] = est_volume_gal
+    record["est_volume_is_range"] = "Y" if is_range else "N"
+    record["est_volume_range_label"] = range_label

--- a/tests/test_sso_volume.py
+++ b/tests/test_sso_volume.py
@@ -1,0 +1,46 @@
+import pytest
+from datetime import datetime
+
+from sso_analytics import build_dashboard_summary
+from sso_schema import START_DATE_FIELD, normalize_sso_records
+from sso_volume import enrich_est_volume_fields, parse_est_volume
+
+
+@pytest.mark.parametrize(
+    "raw, expected_gal, is_range, label",
+    [
+        ("25,000", 25000, False, None),
+        ("<=1,0", 1000, True, "0 - 1,000"),
+        ("1,000 < gall", 10000, True, "1,000 - 10,000"),
+        ("10,000 < gall", 25000, True, "10,000 - 25,000"),
+        ("250,000 < gall", 500000, True, "250,000 - 500,000"),
+        ("500,000 < gall", 750000, True, "500,000 - 750,000"),
+        ("750,000 < gallo", 1_000_000, True, "750,000 - 1,000,000"),
+        ("1,000,000 < gall", 1_000_000, True, "≥ 1,000,000"),
+    ],
+)
+def test_parse_est_volume_cases(raw, expected_gal, is_range, label):
+    est_volume_gal, parsed_is_range, range_label = parse_est_volume(raw)
+    assert est_volume_gal == expected_gal
+    assert parsed_is_range is is_range
+    assert range_label == label
+
+
+def test_dashboard_summary_uses_estimated_volume_upper_bound():
+    raw_records = [
+        {"est_volume": "10,000 < gall", START_DATE_FIELD: datetime(2024, 1, 1)},
+        {"est_volume": "25,000", START_DATE_FIELD: datetime(2024, 1, 2)},
+        {"est_volume": "250,000 < gall", START_DATE_FIELD: datetime(2024, 2, 1)},
+        {"est_volume": None, START_DATE_FIELD: datetime(2024, 2, 5)},
+    ]
+
+    for record in raw_records:
+        enrich_est_volume_fields(record)
+
+    records = normalize_sso_records(raw_records)
+    summary = build_dashboard_summary(records)
+
+    assert summary["summary_counts"]["total_volume"] == 550_000
+    assert summary["summary_counts"]["max_volume"] == 500_000
+    assert summary["summary_counts"]["avg_volume"] == pytest.approx(183_333.3333, rel=1e-6)
+    assert all(item.get("total_volume") for item in summary["by_month"])


### PR DESCRIPTION
## Summary
- add a reusable parser for ADEM estimated volume strings and expose structured fields
- enrich downloaded/API records with parsed volume values so dashboard summaries use numeric estimates
- document the new volume fields and cover parsing/aggregation with unit tests

## Testing
- pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693087fecbb4832b9b6558c3e83817c0)