### PR TITLE
Polish dashboard metrics and filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Module I layers a human-friendly dashboard on top of the FastAPI app and analyti
 {
   "summary_counts": {
     "total_records": 123,
+    "total_spills": 123,
     "total_volume_gallons": 456789.0,
     "total_duration_hours": 12.5,
     "distinct_utilities": 8,
@@ -106,12 +107,16 @@ Module I layers a human-friendly dashboard on top of the FastAPI app and analyti
   "time_series": {"granularity": "month"|"year"|"none", "points": [...]},
   "top_utilities": [...],
   "top_utilities_pie": [...],
-  "top_receiving_waters": [...],
+  "top_receiving_waters": [
+    {"receiving_water": "Dog River", "spill_count": 2, "total_volume_gallons": 1500.0}
+  ],
   "receiving_waters_pie": [...]
 }
 ```
 
-Chart series and tables honor the requested filters. Pie slices are omitted when the user filters to a single utility or when total volume is zero.
+Chart series and tables honor the requested filters. Pie slices are omitted when the user filters to a single utility or when total volume is zero. Time-series points are only emitted for date spans of 60 days or longer, and the UI hides the charts for shorter windows.
+
+Utility filtering accepts full permittee names (e.g., "City of Fairhope") and an optional `permit` query parameter for power users who want to scope to a specific NPDES ID. County filtering uses the full Alabama county list and is available as a search-as-you-type field in the UI.
 
 The legacy Playwright-based downloader/parser scripts remain available below but are treated as legacy compared to the ArcGIS path above.
 

--- a/sso_schema.py
+++ b/sso_schema.py
@@ -166,6 +166,7 @@ class SSOQuery:
 
     utility_id: Optional[str] = None
     utility_name: Optional[str] = None
+    permit_ids: Optional[List[str]] = None
     county: Optional[str] = None
     start_date: Optional[date] = None
     end_date: Optional[date] = None
@@ -208,7 +209,13 @@ class SSOQuery:
 
         if self.county:
             clauses.append(f"{COUNTY_FIELD} = '{self._quote(self.county)}'")
-        if self.utility_id:
+        if self.permit_ids:
+            permit_values = ",".join(
+                f"'{self._quote(permit)}'" for permit in self.permit_ids if permit
+            )
+            if permit_values:
+                clauses.append(f"{UTILITY_ID_FIELD} IN ({permit_values})")
+        elif self.utility_id:
             clauses.append(f"{UTILITY_ID_FIELD} = '{self._quote(self.utility_id)}'")
         if self.utility_name:
             clauses.append(f"{UTILITY_NAME_FIELD} = '{self._quote(self.utility_name)}'")

--- a/tests/test_webapp_api.py
+++ b/tests/test_webapp_api.py
@@ -35,6 +35,18 @@ class DummyClient:
     def list_counties(self):  # pragma: no cover - simple stub
         return self.counties
 
+    def permittee_permit_map(self):  # pragma: no cover - simple stub
+        return {
+            item["name"].lower(): {"label": item["name"], "permits": [item["id"]]}
+            for item in self.utilities
+        }
+
+    def list_permittees(self):  # pragma: no cover - simple stub
+        return [
+            {"id": item["id"], "name": item["name"], "permits": [item["id"]]}
+            for item in self.utilities
+        ]
+
 
 def _set_client_override(records: List[dict]) -> TestClient:
     dummy = DummyClient(records)

--- a/webapp/templates/index.html
+++ b/webapp/templates/index.html
@@ -31,8 +31,8 @@
         .cards { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 0.75rem; margin-bottom: 1rem; }
         .card { background: var(--panel); padding: 0.9rem 1rem; border-radius: 10px; border: 1px solid var(--border); box-shadow: 0 1px 2px rgba(0,0,0,0.05); }
         .card-title { color: var(--muted); font-size: 0.85rem; }
-        .card-value { font-size: 1.5rem; font-weight: 800; margin-top: 0.25rem; }
-        .card-sub { color: var(--muted); font-size: 0.85rem; margin-top: 0.25rem; }
+        .card-body { margin-top: 0.35rem; line-height: 1.45; }
+        .card-sub { color: var(--muted); font-size: 0.85rem; margin-top: 0.35rem; }
         .charts { display: grid; grid-template-columns: repeat(auto-fit, minmax(320px, 1fr)); gap: 1rem; }
         .chart-empty { color: var(--muted); font-style: italic; text-align: center; padding: 1.25rem 0.5rem; }
         .section-title { font-size: 1.05rem; margin: 1rem 0 0.5rem; font-weight: 800; }
@@ -68,6 +68,11 @@
                     <button class="clear-btn" type="button" data-target="utility-search" aria-label="Clear utility">×</button>
                 </div>
                 <div class="searchable">
+                    <label for="permit-search">Permit number (optional)</label>
+                    <input id="permit-search" type="text" placeholder="Type a permit (e.g., AL0027561)" />
+                    <button class="clear-btn" type="button" data-target="permit-search" aria-label="Clear permit">×</button>
+                </div>
+                <div class="searchable">
                     <label for="county-search">County</label>
                     <input id="county-search" type="text" list="county-options" placeholder="Search counties" />
                     <datalist id="county-options"></datalist>
@@ -88,19 +93,18 @@
                 <div id="dashboard" class="hidden" aria-live="polite">
                     <div class="cards">
                         <div class="card">
-                            <div class="card-title">Total spills</div>
-                            <div class="card-value" id="card-total-spills">–</div>
+                            <div class="card-title">Raw sewage spills</div>
+                            <div class="card-body" id="card-spills-text">–</div>
                             <div class="card-sub" id="card-date-range">&nbsp;</div>
                         </div>
                         <div class="card">
-                            <div class="card-title">Total gallons spilled</div>
-                            <div class="card-value" id="card-total-volume">–</div>
-                            <div class="card-sub">Distinct utilities: <span id="card-distinct-utils">–</span></div>
+                            <div class="card-title">Gallons of raw sewage</div>
+                            <div class="card-body" id="card-volume-text">–</div>
+                            <div class="card-sub" id="card-distincts">–</div>
                         </div>
                         <div class="card">
-                            <div class="card-title">Total duration (hrs)</div>
-                            <div class="card-value" id="card-total-duration">–</div>
-                            <div class="card-sub">Receiving waters: <span id="card-distinct-waters">–</span></div>
+                            <div class="card-title">Time sewage was spilling</div>
+                            <div class="card-body" id="card-duration-text">–</div>
                         </div>
                         <div class="card" id="equivalents-card">
                             <div class="card-title">How much is that?</div>
@@ -108,7 +112,7 @@
                         </div>
                     </div>
 
-                    <div class="charts">
+                    <div class="charts" id="charts-time-series">
                         <div class="panel">
                             <h2>Spills over time</h2>
                             <div id="chart-count-empty" class="chart-empty" hidden>No data for the selected range.</div>
@@ -120,14 +124,15 @@
                             <canvas id="chart-volume"></canvas>
                         </div>
                     </div>
+                    <div id="chart-range-note" class="panel chart-empty hidden" aria-live="polite">Time-series charts are shown for date ranges of 60 days or longer.</div>
 
                     <h2 class="section-title">Top receiving waters</h2>
                     <div class="two-col">
                         <div class="panel table-container">
                             <table id="receiving-table">
                                 <thead>
-                                    <tr>
-                                        <th data-sort="receiving_water_name">Receiving water</th>
+                                        <tr>
+                                        <th data-sort="receiving_water">Receiving water</th>
                                         <th data-sort="total_volume_gallons">Total volume</th>
                                         <th data-sort="spill_count">Spills</th>
                                     </tr>


### PR DESCRIPTION
## Summary
- add permittee-aware filters and permit precedence in the API along with better receiving-water volume aggregation
- rewrite the preview dashboard cards, equivalents, pies, and time-series visibility to use polished copy and current data
- document the updated summary payload and filter behavior for the dashboard

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69309f285dfc832b9e7dbca5a302d27c)