### PR TITLE
Expand web dashboard limits and format CSV dates

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,12 +80,12 @@ Module I layers a human-friendly dashboard on top of the FastAPI app and analyti
 - **Run locally:** `uvicorn webapp.api:app --reload` and open `http://127.0.0.1:8000/dashboard`.
 - **Highlights:** headline stat cards now narrate total spills, gallons, and duration using the full ArcGIS dataset (with pagination under the hood); receiving-water names are normalized for charts/tables; utility filtering is permittee-based and county filtering uses the full county list; volume-share tooltips keep labels aligned with data.
 - **Controls:** searchable utility and county selectors populate from `/api/options`, and the buttons read “Summarize” (refresh the view) and “Download the data” (CSV).
-- **Notes:** Long, multi-year date ranges may take extra time to paginate through ArcGIS, but the summary will reflect all returned pages rather than the first 5,000 rows.
+- **Notes:** Long, multi-year date ranges may take extra time to paginate through ArcGIS, but the summary now paginates through all available pages (up to ~20,000 records by default) instead of stopping at the first few thousand rows.
 - **Features:**
   - Filters for utility, county, and date range (with optional record limit for the table).
   - Summary cards for totals, distinct utilities, and volume statistics with a visible date range.
   - Charts for spills by month, volume by utility (top 10), and counts by volume bucket (Chart.js via CDN).
-  - Tabular record preview sourced from `/api/ssos` with a CSV download button wired to `/api/ssos.csv`.
+  - Tabular record preview sourced from `/api/ssos` with a CSV download button wired to `/api/ssos.csv`. CSV exports format ArcGIS date fields in Central time, matching the CLI output.
 - **Dashboard API endpoints:**
   - `/api/options` (or `/filters`) – utility and county options for form controls.
   - `/api/ssos/summary` – aggregate metrics (totals plus by-month, by-utility, and volume buckets).

--- a/sso_analytics.py
+++ b/sso_analytics.py
@@ -550,7 +550,9 @@ def build_receiving_water_pie(
     return _pie(entries, total_volume, key="total_volume_gallons")
 
 
-def build_dashboard_summary(records: Sequence[SSORecord]) -> Dict[str, Any]:
+def build_dashboard_summary(
+    records: Sequence[SSORecord], *, date_range: Optional[Dict[str, Optional[str]]] = None
+) -> Dict[str, Any]:
     """Build a dashboard-friendly summary payload."""
 
     volumes = [vol for vol in (_best_volume(record) for record in records) if vol is not None]
@@ -574,6 +576,10 @@ def build_dashboard_summary(records: Sequence[SSORecord]) -> Dict[str, Any]:
     date_values = [record.date_sso_began for record in records if record.date_sso_began]
     date_min = min(date_values).date().isoformat() if date_values else None
     date_max = max(date_values).date().isoformat() if date_values else None
+
+    if date_range is not None:
+        date_min = date_range.get("min") or date_min
+        date_max = date_range.get("max") or date_max
 
     time_series = build_time_series(records)
     top_utils = summarize_top_utilities(records)


### PR DESCRIPTION
## Summary
- raise web dashboard fetch limits to paginate larger result sets and use requested date ranges in summaries
- normalize CSV exports to reuse schema helpers and emit Central time date strings consistent with the CLI
- document the higher default cap and timezone-aligned CSV output

## Testing
- pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931e425bb94832bb383a410e9e5b973)