### PR TITLE
Fix pie chart tooltip typing, remove Google font fetch, and guard middleware env

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -3,13 +3,16 @@
 :root {
   --background: #ffffff;
   --foreground: #171717;
+  --font-sans: "Inter", system-ui, -apple-system, "Segoe UI", sans-serif;
+  --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
+    "Courier New", monospace;
 }
 
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
+  --font-sans: var(--font-sans);
+  --font-mono: var(--font-mono);
 }
 
 @media (prefers-color-scheme: dark) {
@@ -22,5 +25,5 @@
 body {
   background: var(--background);
   color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: var(--font-sans);
 }

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,16 +1,5 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
-
-const geistSans = Geist({
-  variable: "--font-geist-sans",
-  subsets: ["latin"],
-});
-
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
-});
 
 export const metadata: Metadata = {
   title: "Create Next App",
@@ -24,11 +13,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-      >
-        {children}
-      </body>
+      <body className="antialiased">{children}</body>
     </html>
   );
 }

--- a/frontend/src/components/dashboard/SSOCharts.tsx
+++ b/frontend/src/components/dashboard/SSOCharts.tsx
@@ -120,10 +120,19 @@ export function SSOCharts({ timeSeries, barGroups, pieData, onPieClick }: SSOCha
                                 <Tooltip
                                     contentStyle={{ backgroundColor: '#0f172a', borderColor: '#1e293b' }}
                                     itemStyle={{ color: '#e2e8f0' }}
-                                    formatter={(value: ValueType) => {
+                                    formatter={(value?: ValueType) => {
                                         if (Array.isArray(value)) {
                                             const firstValue = value[0]
-                                            return `${typeof firstValue === 'number' ? firstValue.toLocaleString() : firstValue ?? 0} gal`
+                                            if (typeof firstValue === 'number') {
+                                                return `${firstValue.toLocaleString()} gal`
+                                            }
+
+                                            if (typeof firstValue === 'string') {
+                                                const numeric = Number(firstValue)
+                                                return `${Number.isNaN(numeric) ? firstValue : numeric.toLocaleString()} gal`
+                                            }
+
+                                            return '0 gal'
                                         }
 
                                         if (typeof value === 'number') {

--- a/frontend/src/lib/supabase/middleware.ts
+++ b/frontend/src/lib/supabase/middleware.ts
@@ -2,13 +2,21 @@ import { createServerClient } from '@supabase/ssr'
 import { NextResponse, type NextRequest } from 'next/server'
 
 export async function updateSession(request: NextRequest) {
+    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+    const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+
+    if (!supabaseUrl || !supabaseAnonKey) {
+        console.error('Supabase environment variables are missing; allowing request to continue without auth check.')
+        return NextResponse.next({ request })
+    }
+
     let supabaseResponse = NextResponse.next({
         request,
     })
 
     const supabase = createServerClient(
-        process.env.NEXT_PUBLIC_SUPABASE_URL!,
-        process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+        supabaseUrl,
+        supabaseAnonKey,
         {
             cookies: {
                 getAll() {


### PR DESCRIPTION
## Summary
- update the pie chart tooltip formatter to safely handle undefined and array values while always returning a formatted string
- switch the layout to system fonts so builds no longer depend on fetching Google Fonts
- allow middleware to continue when Supabase environment variables are missing, logging the configuration gap instead of failing the request

## Testing
- npm run build (warnings about Recharts container dimensions during static export)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69532ad28c78832b96dcd1f0b53ec2e9)