### PR TITLE
Ensure Vercel routes Next traffic from root

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,37 +1,15 @@
 {
-  "rewrites": [
-    {
-      "source": "/api/ssos",
-      "destination": "/api/index.py"
-    },
-    {
-      "source": "/api/ssos.csv",
-      "destination": "/api/index.py"
-    },
-    {
-      "source": "/api/options",
-      "destination": "/api/index.py"
-    },
-    {
-      "source": "/summary",
-      "destination": "/api/index.py"
-    },
-    {
-      "source": "/series/(.*)",
-      "destination": "/api/index.py"
-    },
-    {
-      "source": "/records",
-      "destination": "/api/index.py"
-    },
-    {
-      "source": "/filters",
-      "destination": "/api/index.py"
-    },
-    {
-      "source": "/download",
-      "destination": "/api/index.py"
-    }
+  "version": 2,
+  "routes": [
+    { "src": "/api/ssos", "dest": "/api/index.py" },
+    { "src": "/api/ssos.csv", "dest": "/api/index.py" },
+    { "src": "/api/options", "dest": "/api/index.py" },
+    { "src": "/summary", "dest": "/api/index.py" },
+    { "src": "/series/(.*)", "dest": "/api/index.py" },
+    { "src": "/records", "dest": "/api/index.py" },
+    { "src": "/filters", "dest": "/api/index.py" },
+    { "src": "/download", "dest": "/api/index.py" },
+    { "src": "/(.*)", "dest": "frontend/$1" }
   ],
   "builds": [
     {

--- a/vercel.json
+++ b/vercel.json
@@ -4,12 +4,15 @@
     { "src": "/api/ssos", "dest": "/api/index.py" },
     { "src": "/api/ssos.csv", "dest": "/api/index.py" },
     { "src": "/api/options", "dest": "/api/index.py" },
+    { "src": "/api/ssos/summary", "dest": "/api/index.py" },
+    { "src": "/health", "dest": "/api/index.py" },
     { "src": "/summary", "dest": "/api/index.py" },
     { "src": "/series/(.*)", "dest": "/api/index.py" },
     { "src": "/records", "dest": "/api/index.py" },
     { "src": "/filters", "dest": "/api/index.py" },
     { "src": "/download", "dest": "/api/index.py" },
-    { "src": "/(.*)", "dest": "frontend/$1" }
+    { "src": "/dashboard", "dest": "/api/index.py" },
+    { "src": "/(.*)", "dest": "/frontend/$1" }
   ],
   "builds": [
     {


### PR DESCRIPTION
## Summary
- declare the Vercel config version and move API rewrites into explicit routes
- add a catch-all route so frontend requests are directed to the Next.js app in the frontend folder

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69533374d698832ba02561a4d2f3295f)